### PR TITLE
Update README to avoid installation errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ curl --resolve 'codeload.github.com:443:20.201.28.149' 'https://codeload.github.
 
 tar -xf wsl2-dnsfix.tar.gz
 
-sudo sh wsl2-dns-fix-config-1.0.0/run.sh
+cd wsl2-dns-fix-config-1.0.0
+
+sudo sh ./run.sh
 ```
 This will work in distros like Ubuntu 22.04 which are not recognizing github.com out of the box.
 


### PR DESCRIPTION
Original instructions caused errors:
```
$ curl --resolve 'codeload.github.com:443:20.201.28.149' 'https://codeload.github.com/epomatti/wsl2-dns-fix-config/tar.gz/refs/tags/v1.0.0' -o wsl2-dnsfix.tar.gz

$ tar -xf wsl2-dnsfix.tar.gz
$ sudo sh wsl2-dns-fix-config-1.0.0/run.sh
cp: cannot stat './dist/wsl.conf': No such file or directory
cp: cannot stat './dist/resolv.conf': No such file or directory
chattr: No such file or directory while trying to stat /etc/resolv.conf
WSL name resolution configured
Restart WSL on Windows: "wsl --shudown"
```
