### PR TITLE
add option to set custom dns servers

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -10,10 +10,23 @@ rm -f $resolv
 
 # Create custom WSL name resolution
 cp ./dist/wsl.conf $wsl
-cp ./dist/resolv.conf $resolv
+
+# Check if --dnsserver argument is provided
+if [ "$1" = "--dnsservers" ]; then
+    shift
+    # Create a new resolv.conf file with default dns servers
+    cp ./dist/resolv.conf $resolv
+    
+    #overwrite the resolv.conf with with the given nameservers
+    for server in "$@"; do
+        echo "nameserver $server" >> $resolv
+    done
+else
+    cp ./dist/resolv.conf $resolv
+fi
 
 # This prevents resolv.conf from being deleted when WSL starts
-chattr +i $resolv
+#chattr +i $resolv
 
 echo 'WSL name resolution configured'
 echo 'Restart WSL on Windows: "wsl --shutdown"'

--- a/run.sh
+++ b/run.sh
@@ -15,7 +15,7 @@ cp ./dist/wsl.conf $wsl
 if [ "$1" = "--dnsservers" ]; then
     shift
     # Create a new resolv.conf file with default dns servers
-    cp ./dist/resolv.conf $resolv
+    
     
     #overwrite the resolv.conf with with the given nameservers
     for server in "$@"; do
@@ -26,7 +26,7 @@ else
 fi
 
 # This prevents resolv.conf from being deleted when WSL starts
-#chattr +i $resolv
+chattr +i $resolv
 
 echo 'WSL name resolution configured'
 echo 'Restart WSL on Windows: "wsl --shutdown"'


### PR DESCRIPTION
Minor add to the current script that allows users to set their own dns servers.


`./run.sh --dnsservers 1.1.1.1 2.2.2.2` will add two nameserver entries.

`./run.sh` will still set googles 8.8.8.8